### PR TITLE
CORE-3212 Add elapsed_time field to scoreboard

### DIFF
--- a/internal/api/xml/match_summary.go
+++ b/internal/api/xml/match_summary.go
@@ -105,6 +105,7 @@ type Scoreboard struct {
 	AwayGoals            *uint32 `xml:"away_goals,attr,omitempty"`
 	Time                 *uint32 `xml:"time,attr,omitempty"`
 	GameTime             *uint32 `xml:"game_time,attr,omitempty"`
+	ElapsedTime          *uint32 `xml:"elapsed_time,attr,omitempty"`
 	CurrentDefenderTeam  *uint32 `xml:"current_def_team,attr,omitempty"`
 
 	// VirtualBasketballScoreboard

--- a/internal/cache/matchStatus.go
+++ b/internal/cache/matchStatus.go
@@ -147,6 +147,7 @@ type scoreboardImpl struct {
 	awayGoals            *uint32
 	time                 *uint32
 	gameTime             *uint32
+	elapsedTime          *uint32
 	currentDefenderTeam  *uint32
 
 	// VirtualBasketballScoreboard
@@ -251,6 +252,10 @@ func (s scoreboardImpl) Time() *uint32 {
 
 func (s scoreboardImpl) GameTime() *uint32 {
 	return s.gameTime
+}
+
+func (s scoreboardImpl) ElapsedTime() *uint32 {
+	return s.elapsedTime
 }
 
 func (s scoreboardImpl) HomeRuns() *uint32 {
@@ -519,6 +524,7 @@ func (m MatchStatusCache) makeFeedScoreboard(scoreboard *feedXML.Scoreboard) pro
 		awayGoals:            scoreboard.AwayGoals,
 		time:                 scoreboard.Time,
 		gameTime:             scoreboard.GameTime,
+		elapsedTime:          scoreboard.ElapsedTime,
 		currentDefenderTeam:  scoreboard.CurrentDefenderTeam,
 		homePoints:           scoreboard.HomePoints,
 		awayPoints:           scoreboard.AwayPoints,
@@ -558,6 +564,7 @@ func (m MatchStatusCache) makeAPIScoreboard(scoreboard *apiXML.Scoreboard) proto
 		awayGoals:            scoreboard.AwayGoals,
 		time:                 scoreboard.Time,
 		gameTime:             scoreboard.GameTime,
+		elapsedTime:          scoreboard.ElapsedTime,
 		currentDefenderTeam:  scoreboard.CurrentDefenderTeam,
 		homePoints:           scoreboard.HomePoints,
 		awayPoints:           scoreboard.AwayPoints,

--- a/internal/feed/xml/sport_event_status.go
+++ b/internal/feed/xml/sport_event_status.go
@@ -87,6 +87,7 @@ type Scoreboard struct {
 	AwayGoals            *uint32 `xml:"away_goals,attr,omitempty"`
 	Time                 *uint32 `xml:"time,attr,omitempty"`
 	GameTime             *uint32 `xml:"game_time,attr,omitempty"`
+	ElapsedTime          *uint32 `xml:"elapsed_time,attr,omitempty"`
 	CurrentDefenderTeam  *uint32 `xml:"current_def_team,attr,omitempty"`
 
 	// VirtualBasketballScoreboard

--- a/protocols/sport_event.go
+++ b/protocols/sport_event.go
@@ -87,6 +87,7 @@ type Scoreboard interface {
 	AwayGoals() *uint32
 	Time() *uint32
 	GameTime() *uint32
+	ElapsedTime() *uint32
 	HomePoints() *uint32
 	AwayPoints() *uint32
 	RemainingGameTime() *uint32


### PR DESCRIPTION
## Summary
- Add `elapsed_time` field (`*uint32`) to the scoreboard, parsed from the XML `elapsed_time` attribute
- Updated feed XML struct, API XML struct, public `Scoreboard` interface, and internal implementation + mapping
- Supports wall-clock seconds since match start for eSim sports (eFootball, eBasketball, Rush Basketball, Rush Madden)

## Context
Panda reported that the existing `time` field can appear to go backwards on their client. Smoke now sends a new `elapsed_time` field (current timestamp minus match start). This PR adds SDK support for it.

Jira: [CORE-3212](https://oddingg.atlassian.net/browse/CORE-3212)

## Test plan
- [ ] Verify field is parsed from live eSim odds_change messages on integration
- [ ] Verify field is nil/absent for non-eSim sports

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-3212]: https://oddingg.atlassian.net/browse/CORE-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ