### PR TITLE
Add CI step to create GitHub Release on version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - 'main'
       - 'develop'
+    tags:
+      - 'v*'
 
 permissions:
   # Required: allow read access to the content for analysis.
@@ -103,3 +105,17 @@ jobs:
           cache: false
       - name: Check
         run: make govulncheck
+
+  release:
+    name: Create GitHub Release
+    needs: [build, tests]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Add GitHub Release creation step to CI pipeline, triggered on `v*` tags
- Uses `softprops/action-gh-release@v2` with auto-generated release notes
- Release job runs after build & test jobs pass

## Test plan
- [ ] Push a `v*` tag and verify the workflow triggers
- [ ] Confirm GitHub Release is created with release notes


🤖 Generated with [Claude Code](https://claude.com/claude-code)