### PR TITLE
fix(whoami): Correct token expiry warning comparison [CORE-3336]

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -311,14 +311,16 @@ func (o *oddsFeedImpl) init() error {
 
 	o.apiClient = api.New(o.cfg)
 
-	o.whoAmIManager = whoami.NewManager(o.cfg, o.apiClient)
+	o.logger = log.NewEntry(log.New())
+
+	o.whoAmIManager = whoami.NewManager(o.cfg, o.apiClient, o.logger)
 	// Try to fetch bookmaker details
 	details, err := o.whoAmIManager.BookmakerDetails()
 	if err != nil {
 		return err
 	}
 
-	o.logger = log.New().WithField("client_id", details.BookmakerID())
+	o.logger = o.logger.WithField("client_id", details.BookmakerID())
 
 	o.producerManager = producer.NewManager(o.cfg, o.apiClient, o.logger)
 

--- a/internal/whoami/manager.go
+++ b/internal/whoami/manager.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+const tokenExpiryWarningWindow = 7 * 24 * time.Hour
+
+func tokenExpiringSoon(exp, now time.Time) bool {
+	return exp.Sub(now) < tokenExpiryWarningWindow
+}
+
 type bookmakerDetailImpl struct {
 	expireAt    time.Time
 	bookmakerID uint
@@ -30,14 +36,15 @@ type Manager struct {
 	bookmakerDetails protocols.BookmakerDetail
 	cfg              protocols.OddsFeedConfiguration
 	apiClient        *api.Client
-	logger           *log.Logger
+	logger           *log.Entry
 }
 
 // NewManager ...
-func NewManager(cfg protocols.OddsFeedConfiguration, client *api.Client) protocols.WhoAmIManager {
+func NewManager(cfg protocols.OddsFeedConfiguration, client *api.Client, logger *log.Entry) protocols.WhoAmIManager {
 	return &Manager{
 		cfg:       cfg,
 		apiClient: client,
+		logger:    logger,
 	}
 }
 
@@ -60,7 +67,7 @@ func (m *Manager) fetchBookmakerDetails() (protocols.BookmakerDetail, error) {
 	}
 
 	exp := time.Time(details.ExpireAt)
-	if exp.After(exp.Add(7 * 24 * time.Hour)) {
+	if tokenExpiringSoon(exp, time.Now()) {
 		m.logger.Warn("access token will expire soon")
 	}
 

--- a/internal/whoami/manager_test.go
+++ b/internal/whoami/manager_test.go
@@ -1,0 +1,34 @@
+package whoami
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTokenExpiringSoon(t *testing.T) {
+	now := time.Date(2026, 4, 29, 12, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		name string
+		exp  time.Time
+		want bool
+	}{
+		{"already expired", now.Add(-1 * time.Hour), true},
+		{"expires now", now, true},
+		{"expires in 1 day", now.Add(24 * time.Hour), true},
+		{"expires in 6 days", now.Add(6 * 24 * time.Hour), true},
+		{"expires 1ns before window boundary", now.Add(7*24*time.Hour - time.Nanosecond), true},
+		{"expires exactly at window boundary", now.Add(7 * 24 * time.Hour), false},
+		{"expires in 8 days", now.Add(8 * 24 * time.Hour), false},
+		{"expires in 30 days", now.Add(30 * 24 * time.Hour), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tokenExpiringSoon(tc.exp, now)
+			if got != tc.want {
+				t.Errorf("tokenExpiringSoon(exp=%v, now=%v) = %v, want %v", tc.exp, now, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
[JIRA issue](https://oddingg.atlassian.net/jira/software/c/projects/CORE/boards/1078?selectedIssue=CORE-3336)

## Summary

The "access token will expire soon" warning in `whoami` had an inverted comparison and never fired.

## Fix

- Correct the comparison (extracted into a pure predicate so it's unit-testable).
- Plumb the SDK's logger into `whoami.NewManager` so the warning can actually log without nil-panicking.
- Add the first test in this repo, covering the predicate.

No public API change.
