### PR TITLE
fix(api): keep all query params in PostReplayStart [CORE-3369]

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -405,8 +405,7 @@ func (c *Client) PostReplayStart(nodeID *int, speed *int, maxDelay *int, useRepl
 		queryParams["run_parallel"] = *runParallel
 	}
 
-	params := make([]string, len(queryParams))
-	var count int
+	params := make([]string, 0, len(queryParams))
 	for key, value := range queryParams {
 		var arg string
 		switch val := value.(type) {
@@ -418,7 +417,7 @@ func (c *Client) PostReplayStart(nodeID *int, speed *int, maxDelay *int, useRepl
 			arg = strconv.FormatBool(val)
 		}
 
-		params[count] = fmt.Sprintf("%s=%s", key, arg)
+		params = append(params, fmt.Sprintf("%s=%s", key, arg))
 	}
 
 	query := strings.Join(params, "&")


### PR DESCRIPTION
## Summary

- `internal/api/client.go` `PostReplayStart` pre-allocated `params` with `len(queryParams)` and wrote to `params[count]` without ever incrementing `count`. Every iteration overwrote `params[0]`.
- Combined with Go's randomized map iteration, all but one configured query param was silently dropped — most notably `node_id`, which made replays under `node_id != 0` fail to start whenever other params were also set (`speed`, `max_delay`, `use_replay_timestamp`, `product`, `run_parallel`).
- Switched to `append`; all configured params now reach the server.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [ ] Manual smoke: trigger `/v1/replay/play?node_id=2&speed=10&max_delay=5000` via SDK and verify the slave receives all four params (was previously dropping `node_id` randomly)

Linked: [CORE-3369](https://oddingg.atlassian.net/browse/CORE-3369)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-3369]: https://oddingg.atlassian.net/browse/CORE-3369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ