### PR TITLE
feat(category): add IconPath to category

### DIFF
--- a/internal/api/xml/tournament.go
+++ b/internal/api/xml/tournament.go
@@ -124,6 +124,7 @@ type Category struct {
 	ID          string  `xml:"id,attr"`
 	Name        string  `xml:"name,attr"`
 	CountryCode *string `xml:"country_code,attr,omitempty"`
+	IconPath    *string `xml:"icon_path,attr,omitempty"`
 }
 
 // TournamentExtended ...

--- a/internal/cache/tournament.go
+++ b/internal/cache/tournament.go
@@ -471,6 +471,7 @@ type categoryImpl struct {
 	id          string
 	name        string
 	countryCode *string
+	iconPath    *string
 }
 
 func (c *categoryImpl) ID() string {
@@ -483,6 +484,10 @@ func (c *categoryImpl) Name() string {
 
 func (c *categoryImpl) CountryCode() *string {
 	return c.countryCode
+}
+
+func (c *categoryImpl) IconPath() *string {
+	return c.iconPath
 }
 
 func (t tournamentImpl) Category() (protocols.Category, error) {
@@ -500,6 +505,7 @@ func (t tournamentImpl) Category() (protocols.Category, error) {
 		id:          category.ID,
 		name:        category.Name,
 		countryCode: category.CountryCode,
+		iconPath:    category.IconPath,
 	}, nil
 }
 

--- a/protocols/sport_event.go
+++ b/protocols/sport_event.go
@@ -196,6 +196,7 @@ type Category interface {
 	ID() string
 	Name() string
 	CountryCode() *string
+	IconPath() *string
 }
 
 // SportSummary ...


### PR DESCRIPTION
## Summary
Adds `IconPath` to category, exposing the `icon_path` attribute that the API already returns for categories. The implementation mirrors the existing `CountryCode` field across all three layers.

## Changes
- `internal/api/xml/tournament.go` — add `IconPath *string` (`xml:"icon_path,attr,omitempty"`) to the `Category` XML struct
- `protocols/sport_event.go` — add `IconPath() *string` to the `Category` interface
- `internal/cache/tournament.go` — add `iconPath` field + `IconPath()` getter to `categoryImpl`, and populate it from `category.IconPath` in `tournamentImpl.Category()`

## Notes
The XML tag name and pointer-return style are consistent with how `IconPath` is already handled for sports, tournaments, and competitors elsewhere in the SDK. There are no mocks of the `Category` interface to update; `go build ./...` and `go vet ./...` pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)